### PR TITLE
Run deterministic service-free evaluator in CI

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -47,23 +47,7 @@ jobs:
           python -m pip install -c constraints.txt -r requirements.txt
           python -m pip install -c constraints.txt -r requirements-dev.txt
 
-      - name: Install Ollama
-        run: |
-          curl -fsSL https://ollama.com/install.sh | sh
-
-      - name: Start Ollama Server
-        run: |
-          ollama serve &
-          # Wait for ollama to be ready
-          sleep 5
-
-      - name: Pull Vision Model
-        run: |
-          # Use a smaller model for CI to avoid memory limits and timeouts on standard runners.
-          ollama pull granite3.2-vision
-
-      - name: Run automated evaluation
+      - name: Run deterministic evaluation smoke
         env:
-          EVAL_MODEL: granite3.2-vision
           EVAL_MAX_IMAGES: 2
-        run: python evaluate.py
+        run: python evaluate.py --allow-mock

--- a/README.MD
+++ b/README.MD
@@ -111,8 +111,9 @@ make check
 `constraints.txt` pins the verified runtime, development, and stable transitive
 dependency set. Python-specific compiled transitive packages are resolved per
 interpreter. CI installs through this file on Python 3.10, 3.11, 3.12, and 3.13
-before running `make check`; the Ollama-backed evaluation runs only once on
-Python 3.11 to keep the workflow practical.
+before running `make check`; the evaluation job runs a deterministic mock smoke
+on Python 3.11 so hosted runners do not depend on downloading or serving local
+vision models.
 
 ### Optional Docling backend
 
@@ -258,7 +259,7 @@ python evaluate.py \
 
 - `--metrics-json`: writes deterministic metrics with run metadata, field counts, aggregate accuracy, backend/profile/preprocess group metrics, detailed rows, and evidence path
 - `--out-evidence`: writes the same evidence JSON shape as the CLI/UI exporter
-- `--allow-mock`: uses deterministic mock `Result` objects when Ollama is unavailable; mock runs never update the README
+- `--allow-mock`: uses deterministic mock `Result` objects when Ollama is unavailable; this keeps CI service-free, and mock runs never update the README
 - `--update-readme`: opt in to refreshing the automated evaluation block below; default evaluation runs do not mutate `README.MD`
 - `--chart-output` and `--detailed-csv`: override the default `eval_results.png` and `eval_detailed_results.csv` artifact paths
 

--- a/Updates.MD
+++ b/Updates.MD
@@ -1,3 +1,9 @@
+## 2026-05-04
+
+- Changed the GitHub Actions evaluation job to run the deterministic service-free evaluator path instead of installing Ollama, starting a server, pulling a vision model, and risking hosted-runner inference timeouts.
+- Added a CI workflow regression test that keeps the evaluation job on `python evaluate.py --allow-mock` and prevents reintroducing live Ollama install/pull steps.
+- Updated README CI notes to distinguish service-free hosted-runner smoke evaluation from local Ollama-backed evaluation.
+
 ## 2026-05-03
 
 - Tightened the branded app header into a compact logo/title lockup with the description aligned under the title, smaller responsive type, and a measured logo size.

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_github_actions_evaluation_uses_service_free_mock_mode() -> None:
+    workflow = Path(".github/workflows/eval.yml").read_text(encoding="utf-8")
+
+    assert "python evaluate.py --allow-mock" in workflow
+    assert "ollama serve" not in workflow
+    assert "ollama pull" not in workflow
+    assert "ollama.com/install.sh" not in workflow


### PR DESCRIPTION
Replace Ollama install/start/pull steps in the GitHub Actions eval job with a deterministic smoke run (python evaluate.py --allow-mock) to avoid hosted-runner model downloads and inference timeouts. Update README to document the service-free CI behavior and tweak the --allow-mock description. Add Updates.MD changelog entry and a new test (tests/test_ci_workflow.py) that asserts the workflow uses the --allow-mock path and contains no Ollama install/serve/pull commands.