### PR TITLE
Add live Ollama CI gate and fail-on-errors

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -33,6 +33,7 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +48,29 @@ jobs:
           python -m pip install -c constraints.txt -r requirements.txt
           python -m pip install -c constraints.txt -r requirements-dev.txt
 
-      - name: Run deterministic evaluation smoke
+      - name: Install Ollama
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start Ollama Server
+        run: |
+          ollama serve > ollama.log 2>&1 &
+          for attempt in {1..30}; do
+            if curl -fsS http://127.0.0.1:11434/api/tags >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat ollama.log
+          exit 1
+
+      - name: Pull Vision Model
+        run: |
+          ollama pull granite3.2-vision
+
+      - name: Run automated evaluation
         env:
+          EVAL_MODEL: granite3.2-vision
           EVAL_MAX_IMAGES: 2
-        run: python evaluate.py --allow-mock
+          LOCALOCR_REQUEST_TIMEOUT: 360
+        run: python evaluate.py --fail-on-errors

--- a/README.MD
+++ b/README.MD
@@ -111,9 +111,9 @@ make check
 `constraints.txt` pins the verified runtime, development, and stable transitive
 dependency set. Python-specific compiled transitive packages are resolved per
 interpreter. CI installs through this file on Python 3.10, 3.11, 3.12, and 3.13
-before running `make check`; the evaluation job runs a deterministic mock smoke
-on Python 3.11 so hosted runners do not depend on downloading or serving local
-vision models.
+before running `make check`; the Ollama-backed evaluation runs once on Python
+3.11 with an extended request timeout and fails the job if any OCR request is
+captured as an error.
 
 ### Optional Docling backend
 
@@ -259,7 +259,8 @@ python evaluate.py \
 
 - `--metrics-json`: writes deterministic metrics with run metadata, field counts, aggregate accuracy, backend/profile/preprocess group metrics, detailed rows, and evidence path
 - `--out-evidence`: writes the same evidence JSON shape as the CLI/UI exporter
-- `--allow-mock`: uses deterministic mock `Result` objects when Ollama is unavailable; this keeps CI service-free, and mock runs never update the README
+- `--allow-mock`: uses deterministic mock `Result` objects when Ollama is unavailable; mock runs never update the README
+- `--fail-on-errors`: exits non-zero after writing artifacts if any evaluated file returned an OCR error; CI uses this for the live Ollama gate
 - `--update-readme`: opt in to refreshing the automated evaluation block below; default evaluation runs do not mutate `README.MD`
 - `--chart-output` and `--detailed-csv`: override the default `eval_results.png` and `eval_detailed_results.csv` artifact paths
 

--- a/Updates.MD
+++ b/Updates.MD
@@ -1,8 +1,9 @@
 ## 2026-05-04
 
-- Changed the GitHub Actions evaluation job to run the deterministic service-free evaluator path instead of installing Ollama, starting a server, pulling a vision model, and risking hosted-runner inference timeouts.
-- Added a CI workflow regression test that keeps the evaluation job on `python evaluate.py --allow-mock` and prevents reintroducing live Ollama install/pull steps.
-- Updated README CI notes to distinguish service-free hosted-runner smoke evaluation from local Ollama-backed evaluation.
+- Kept the GitHub Actions evaluation job as a live Ollama-backed gate, with a readiness loop, a longer request timeout, and a job timeout so hosted-runner startup and inference delays are handled explicitly.
+- Added evaluator `--fail-on-errors` so CI exits non-zero when live OCR requests time out or otherwise return per-file errors after artifacts are written.
+- Added CI and evaluator regressions to prevent replacing the live gate with mock mode and to keep timeout/error results from being reported as successful evaluations.
+- Updated README CI notes and evaluator flag documentation for the live Ollama gate.
 
 ## 2026-05-03
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -452,6 +452,7 @@ def _build_metrics_payload(
             "max_images": max_images,
             "evaluated_files": len(entries),
             "total_results": len(results),
+            "error_results": sum(1 for result in results if result.error),
             "evidence_path": evidence_path,
         },
         "field_accuracy": {
@@ -541,6 +542,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--allow-mock",
         action="store_true",
         help="Fall back to deterministic mock results if Ollama is not running.",
+    )
+    parser.add_argument(
+        "--fail-on-errors",
+        action="store_true",
+        help="Exit non-zero when any evaluated file returns an OCR error.",
     )
     parser.add_argument(
         "--update-readme",
@@ -662,6 +668,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         update_readme(final_metrics, args.chart_output)
     else:
         print("Skipping README update.")
+
+    error_results = metrics_payload["run"]["error_results"]
+    if args.fail_on_errors and error_results:
+        print(
+            f"Evaluation failed: {error_results} result(s) returned OCR errors.",
+            file=sys.stderr,
+        )
+        return 1
 
     print("Evaluation completed successfully.")
     return 0

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
 
-def test_github_actions_evaluation_uses_service_free_mock_mode() -> None:
+def test_github_actions_evaluation_keeps_live_ollama_gate() -> None:
     workflow = Path(".github/workflows/eval.yml").read_text(encoding="utf-8")
 
-    assert "python evaluate.py --allow-mock" in workflow
-    assert "ollama serve" not in workflow
-    assert "ollama pull" not in workflow
-    assert "ollama.com/install.sh" not in workflow
+    assert "curl -fsSL https://ollama.com/install.sh | sh" in workflow
+    assert "ollama serve" in workflow
+    assert "ollama pull granite3.2-vision" in workflow
+    assert "LOCALOCR_REQUEST_TIMEOUT: 360" in workflow
+    assert "python evaluate.py --fail-on-errors" in workflow
+    assert "--allow-mock" not in workflow

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -312,3 +312,59 @@ def test_empty_ground_truth_values_are_ignored_from_metric_totals(
     assert {row["field"] for row in ignored_rows} == {"date", "total"}
     assert {row["ignore_reason"] for row in ignored_rows} == {"empty_ground_truth"}
     assert all(row["match"] is None for row in ignored_rows)
+
+
+def test_fail_on_errors_returns_nonzero_after_writing_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    dataset = _write_dataset(
+        tmp_path,
+        {
+            "invoice.png": {
+                "invoice_number": "INV-42",
+            }
+        },
+    )
+    metrics_path = tmp_path / "metrics.json"
+    details_path = tmp_path / "details.csv"
+    chart_path = tmp_path / "chart.json"
+
+    def fake_run_batch(jobs, cfg):
+        yield Result(
+            source="invoice.png",
+            mode="extract",
+            text="",
+            fields={},
+            error="Ollama chat failed: timed out",
+            engine="ollama",
+            profile_id="generic",
+            preprocess_steps=[],
+        )
+
+    monkeypatch.setattr(evaluate, "is_ollama_running", lambda: True)
+    monkeypatch.setattr(evaluate, "run_batch", fake_run_batch)
+    monkeypatch.setattr(evaluate, "create_chart", _write_chart)
+
+    rc = evaluate.main(
+        [
+            "--dataset",
+            str(dataset),
+            "--model",
+            "fake-model",
+            "--metrics-json",
+            str(metrics_path),
+            "--detailed-csv",
+            str(details_path),
+            "--chart-output",
+            str(chart_path),
+            "--fail-on-errors",
+        ]
+    )
+
+    assert rc == 1
+    assert metrics_path.exists()
+    assert details_path.exists()
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["run"]["error_results"] == 1
+    assert metrics["detailed_rows"][0]["error"] == "Ollama chat failed: timed out"


### PR DESCRIPTION
Switch the GitHub Actions evaluation job to run a live Ollama-backed gate: install Ollama, start a local server with a readiness loop, pull the vision model, and set a 30-minute job timeout and longer OCR request timeout. Add a new CLI flag --fail-on-errors and include error_results in the metrics; when enabled the evaluator exits non-zero if any file returned an OCR error. Update README and Updates.MD to document the live gate and the new flag. Update tests to expect the Ollama install/serve/pull steps and to assert that the evaluator returns a non-zero code and writes artifacts when an OCR error occurs.