### PR TITLE
Refactor pipeline, Ollama adapter, app and CLI

### DIFF
--- a/Updates.MD
+++ b/Updates.MD
@@ -1,3 +1,10 @@
+## 2026-05-29
+
+- Simplified `core.pipeline` PDF page handling, Ollama field/evidence construction, and auto-backend fallback routing with small internal helpers while preserving the existing PDF tuple and fallback semantics.
+- Consolidated Ollama chat message/kwargs/content handling across image, text, and stream requests, with a stream regression covering shared system/image message construction and timeout usage.
+- Moved Streamlit display-entry shaping into a pure helper, closed loaded image handles in app/legacy CLI paths, and kept the CLI JSON summary schema behind a deterministic helper.
+- Verified the refactors with focused pipeline, Ollama adapter, app, CLI, and lint checks before the full regression run.
+
 ## 2026-05-04
 
 - Kept the GitHub Actions evaluation job as a live Ollama-backed gate, with a readiness loop, a longer request timeout, and a job timeout so hosted-runner startup and inference delays are handled explicitly.

--- a/adapters/ollama_adapter.py
+++ b/adapters/ollama_adapter.py
@@ -203,6 +203,69 @@ def get_available_models(
     return ordered or defaults
 
 
+def _messages(
+    prompt: str,
+    *,
+    system_prompt: Optional[str] = None,
+    image_base64: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    messages: List[Dict[str, Any]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    user_message: Dict[str, Any] = {"role": "user", "content": prompt}
+    if image_base64 is not None:
+        user_message["images"] = [image_base64]
+    messages.append(user_message)
+    return messages
+
+
+def _chat_kwargs(
+    *,
+    model: str,
+    messages: List[Dict[str, Any]],
+    options: Optional[dict],
+    format: Optional[OllamaFormat] = None,
+) -> Dict[str, Any]:
+    kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "options": options or {},
+    }
+    if format is not None:
+        kwargs["format"] = format
+    return kwargs
+
+
+def _chat_content(
+    *,
+    model: str,
+    messages: List[Dict[str, Any]],
+    options: Optional[dict],
+    format: Optional[OllamaFormat],
+    settings: Optional[Settings],
+    timeout: Optional[float],
+) -> str:
+    kwargs = _chat_kwargs(
+        model=model,
+        messages=messages,
+        options=options,
+        format=format,
+    )
+
+    try:
+        response = _ollama_api(
+            _request_timeout(settings=settings, timeout=timeout)
+        ).chat(**kwargs)
+        content = response.get("message", {}).get("content", "")
+        if not isinstance(content, str):
+            raise ModelUnavailable("Unexpected response content type from model")
+        return content
+    except ModelUnavailable:
+        raise
+    except Exception as e:
+        raise ModelUnavailable(f"Ollama chat failed: {e}") from e
+
+
 def query_ollama(
     prompt: str,
     image_base64: str,
@@ -215,25 +278,18 @@ def query_ollama(
     timeout: Optional[float] = None,
 ) -> str:
     """Query Ollama chat with an image, returning content string."""
-    messages: List[Dict[str, Any]] = []
-    if system_prompt:
-        messages.append({"role": "system", "content": system_prompt})
-    messages.append({"role": "user", "content": prompt, "images": [image_base64]})
-
-    try:
-        kwargs: Dict[str, Any] = {"model": model, "messages": messages, "options": options or {}}
-        if format is not None:
-            kwargs["format"] = format
-
-        response = _ollama_api(_request_timeout(settings=settings, timeout=timeout)).chat(**kwargs)
-        content = response.get("message", {}).get("content", "")
-        if not isinstance(content, str):
-            raise ModelUnavailable("Unexpected response content type from model")
-        return content
-    except ModelUnavailable:
-        raise
-    except Exception as e:
-        raise ModelUnavailable(f"Ollama chat failed: {e}") from e
+    return _chat_content(
+        model=model,
+        messages=_messages(
+            prompt,
+            system_prompt=system_prompt,
+            image_base64=image_base64,
+        ),
+        options=options,
+        format=format,
+        settings=settings,
+        timeout=timeout,
+    )
 
 
 def query_ollama_text(
@@ -247,25 +303,14 @@ def query_ollama_text(
     timeout: Optional[float] = None,
 ) -> str:
     """Query Ollama chat with text only, returning content string."""
-    messages: List[Dict[str, Any]] = []
-    if system_prompt:
-        messages.append({"role": "system", "content": system_prompt})
-    messages.append({"role": "user", "content": prompt})
-
-    try:
-        kwargs: Dict[str, Any] = {"model": model, "messages": messages, "options": options or {}}
-        if format is not None:
-            kwargs["format"] = format
-
-        response = _ollama_api(_request_timeout(settings=settings, timeout=timeout)).chat(**kwargs)
-        content = response.get("message", {}).get("content", "")
-        if not isinstance(content, str):
-            raise ModelUnavailable("Unexpected response content type from model")
-        return content
-    except ModelUnavailable:
-        raise
-    except Exception as e:
-        raise ModelUnavailable(f"Ollama chat failed: {e}") from e
+    return _chat_content(
+        model=model,
+        messages=_messages(prompt, system_prompt=system_prompt),
+        options=options,
+        format=format,
+        settings=settings,
+        timeout=timeout,
+    )
 
 
 def query_ollama_stream(
@@ -279,16 +324,15 @@ def query_ollama_stream(
     timeout: Optional[float] = None,
 ) -> Iterator[str]:
     """Yield content chunks from Ollama's streaming chat API."""
-    messages: List[Dict[str, Any]] = []
-    if system_prompt:
-        messages.append({"role": "system", "content": system_prompt})
-    messages.append({"role": "user", "content": prompt, "images": [image_base64]})
-
     try:
         api = _ollama_api(_request_timeout(settings=settings, timeout=timeout))
         for chunk in api.chat(
             model=model,
-            messages=messages,
+            messages=_messages(
+                prompt,
+                system_prompt=system_prompt,
+                image_base64=image_base64,
+            ),
             options=options or {},
             stream=True,
         ):

--- a/app.py
+++ b/app.py
@@ -149,6 +149,29 @@ def _count_items(uploaded_files, pdf_process_mode: str) -> int:
     return total
 
 
+def _display_entry_from_result(result: Result) -> Dict[str, Any]:
+    return {
+        "filename": result.source,
+        "content": result.text if not result.error else "",
+        "duration_sec": (
+            round(result.latency_ms / 1000.0, 3) if result.latency_ms else None
+        ),
+        "dimensions": result.dimensions,
+        "encoded_bytes": result.encoded_bytes,
+        "structured_data": (
+            {"filename": result.source, **result.fields} if result.fields else None
+        ),
+        "image_bytes": result.preview_image_bytes,
+        "page_note": None,
+        "status": "error" if result.error else "done",
+        "error": result.error,
+        "engine": result.engine,
+        "profile_id": result.profile_id,
+        "backend_note": result.backend_note,
+        "field_evidence": result.field_evidence,
+    }
+
+
 def run_processing(state: SidebarState, results_placeholder) -> None:
     progress_bar = st.progress(0)
     status_text = st.empty()
@@ -206,9 +229,9 @@ def run_processing(state: SidebarState, results_placeholder) -> None:
                 continue
             job = BatchJob(source=uf.name, data=file_bytes, kind="pdf")
         else:
-            img = Image.open(uf)
-            img.load()
-            job = BatchJob(source=uf.name, data=img, kind="image")
+            with Image.open(uf) as img:
+                img.load()
+                job = BatchJob(source=uf.name, data=img.copy(), kind="image")
 
         for result in _run_batch([job], cfg):
             status_text.text(f"Processing {result.source}")
@@ -216,23 +239,7 @@ def run_processing(state: SidebarState, results_placeholder) -> None:
             if result.latency_ms:
                 durations.append(result.latency_ms / 1000.0)
 
-            entry: Dict[str, Any] = {
-                "filename": result.source,
-                "content": result.text if not result.error else "",
-                "duration_sec": round(result.latency_ms / 1000.0, 3) if result.latency_ms else None,
-                "dimensions": result.dimensions,
-                "encoded_bytes": result.encoded_bytes,
-                "structured_data": ({"filename": result.source, **result.fields} if result.fields else None),
-                "image_bytes": result.preview_image_bytes,
-                "page_note": None,
-                "status": "error" if result.error else "done",
-                "error": result.error,
-                "engine": result.engine,
-                "profile_id": result.profile_id,
-                "backend_note": result.backend_note,
-                "field_evidence": result.field_evidence,
-            }
-            entries.append(entry)
+            entries.append(_display_entry_from_result(result))
             render_results(results_placeholder, entries, state.show_images, state.compact_view)
 
             processed += 1

--- a/cli.py
+++ b/cli.py
@@ -162,19 +162,20 @@ def _process_file(
                 _, _, img = first_entry
                 _handle_page(img, filename)
         else:
-            image = Image.open(path)
-            result, content, structured_data = process_image(
-                image,
-                filename,
-                fields,
-                model=model,
-                system_prompt=system_prompt,
-                options=options,
-                max_image_size=max_image_size,
-                jpeg_quality=jpeg_quality,
-                inference=inference,
-                prompts=prompts,
-            )
+            with Image.open(path) as image:
+                image.load()
+                result, content, structured_data = process_image(
+                    image,
+                    filename,
+                    fields,
+                    model=model,
+                    system_prompt=system_prompt,
+                    options=options,
+                    max_image_size=max_image_size,
+                    jpeg_quality=jpeg_quality,
+                    inference=inference,
+                    prompts=prompts,
+                )
             results.append(result)
             if structured_data and len(structured_data) > 1:
                 structured.append(structured_data)
@@ -186,6 +187,27 @@ def _process_file(
         _log.exception("cli_file_failed", extra={"path": path})
         results.append({"filename": filename, "description": f"Error: {e}"})
     return results, structured
+
+
+def _json_summary_payload(
+    results: List[Result], processed_files: int
+) -> Dict[str, object]:
+    return {
+        "ok": not any(r.error for r in results),
+        "processed_files": processed_files,
+        "total_results": len(results),
+        "results": [
+            {
+                "source": r.source,
+                "mode": r.mode,
+                "text": r.text,
+                "fields": r.fields,
+                "error": r.error,
+                "latency_ms": r.latency_ms,
+            }
+            for r in results
+        ],
+    }
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -348,23 +370,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         write_evidence(all_results, args.out_evidence)
         wrote.append(args.out_evidence)
     if args.json:
-        payload = {
-            "ok": not any(r.error for r in all_results),
-            "processed_files": len(args.files),
-            "total_results": len(all_results),
-            "results": [
-                {
-                    "source": r.source,
-                    "mode": r.mode,
-                    "text": r.text,
-                    "fields": r.fields,
-                    "error": r.error,
-                    "latency_ms": r.latency_ms,
-                }
-                for r in all_results
-            ],
-        }
-        print(json.dumps(payload, ensure_ascii=False))
+        print(
+            json.dumps(
+                _json_summary_payload(all_results, processed_files=len(args.files)),
+                ensure_ascii=False,
+            )
+        )
     elif not args.quiet:
         print("Wrote: " + ", ".join(wrote))
 

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -34,7 +34,7 @@ from core.image_utils import (
 )
 from core.json_extract import extract_structured_data
 from core.logging import get_logger
-from core.models import Mode, Result
+from core.models import FieldEvidence, Mode, Result
 from core.ocr_backends import (
     BACKEND_AUTO,
     BACKEND_DOCLING,
@@ -241,6 +241,39 @@ def process_pdf(
     preprocess: str = "none",
 ) -> Generator[PDFPageResult, None, None]:
     """Process a PDF file using PyMuPDF, yielding page-level results."""
+
+    def _process_page(
+        page_num: int,
+        page_count: int,
+        image: Image.Image,
+        page_filename: str,
+    ) -> PDFPageResult:
+        result, content, structured_data = process_image(
+            image,
+            page_filename,
+            fields,
+            model=model,
+            system_prompt=system_prompt,
+            options=options,
+            max_image_size=max_image_size,
+            jpeg_quality=jpeg_quality,
+            inference=inference,
+            prompts=prompts,
+            settings=settings,
+            preprocess=preprocess,
+        )
+        return (
+            page_num,
+            page_count,
+            image,
+            page_filename,
+            content,
+            structured_data,
+            _number_as_float(result.get("duration_sec")),
+            _dimensions_from_result(result),
+            _int_value(result.get("encoded_bytes")),
+        )
+
     try:
         ensure_pdf_support()
         if process_pages_separately:
@@ -248,67 +281,13 @@ def process_pdf(
                 file_bytes, scale=pdf_scale
             ):
                 page_filename = f"{filename} (Page {page_num + 1})"
-                result, content, structured_data = process_image(
-                    img,
-                    page_filename,
-                    fields,
-                    model=model,
-                    system_prompt=system_prompt,
-                    options=options,
-                    max_image_size=max_image_size,
-                    jpeg_quality=jpeg_quality,
-                    inference=inference,
-                    prompts=prompts,
-                    settings=settings,
-                    preprocess=preprocess,
-                )
-                elapsed = _number_as_float(result.get("duration_sec"))
-                dims = _dimensions_from_result(result)
-                size_bytes = _int_value(result.get("encoded_bytes"))
-                yield (
-                    page_num,
-                    page_count,
-                    img,
-                    page_filename,
-                    content,
-                    structured_data,
-                    elapsed,
-                    dims,
-                    size_bytes,
-                )
+                yield _process_page(page_num, page_count, img, page_filename)
         else:
             first = next(iter_pdf_pages(file_bytes, scale=pdf_scale), None)
             if first is None:
                 raise PDFError("PDF contains no renderable pages.")
-            page_num, page_count, img = first
-            result, content, structured_data = process_image(
-                img,
-                filename,
-                fields,
-                model=model,
-                system_prompt=system_prompt,
-                options=options,
-                max_image_size=max_image_size,
-                jpeg_quality=jpeg_quality,
-                inference=inference,
-                prompts=prompts,
-                settings=settings,
-                preprocess=preprocess,
-            )
-            elapsed = _number_as_float(result.get("duration_sec"))
-            dims = _dimensions_from_result(result)
-            size_bytes = _int_value(result.get("encoded_bytes"))
-            yield (
-                0,
-                page_count,
-                img,
-                filename,
-                content,
-                structured_data,
-                elapsed,
-                dims,
-                size_bytes,
-            )
+            _page_num, page_count, img = first
+            yield _process_page(0, page_count, img, filename)
     except PDFNotSupportedError as e:
         yield None, None, None, filename, str(e), None, None, None, None
     except Exception as e:
@@ -392,6 +371,34 @@ def _preprocess_steps(result: JSONDict) -> List[str]:
     if isinstance(steps, list) and all(isinstance(step, str) for step in steps):
         return list(steps)
     return []
+
+
+def _fields_and_evidence(
+    *,
+    requested_fields: Optional[List[str]],
+    structured: Optional[JSONDict],
+    raw_content: str,
+    engine: str,
+    page: Optional[int] = None,
+) -> tuple[JSONDict, dict[str, FieldEvidence]]:
+    clean_fields: JSONDict = {}
+    if structured:
+        parsed_fields = {k: v for k, v in structured.items() if k != "filename"}
+        clean_fields = clean_result_fields(
+            requested_fields=requested_fields,
+            parsed_fields=parsed_fields,
+        )
+
+    field_evidence: dict[str, FieldEvidence] = {}
+    if requested_fields:
+        field_evidence = build_field_evidence(
+            requested_fields=requested_fields,
+            parsed_fields=clean_fields,
+            raw_content=raw_content,
+            engine=engine,
+            page=page,
+        )
+    return clean_fields, field_evidence
 
 
 def _expected_preprocess_steps(preprocess: str) -> List[str]:
@@ -588,22 +595,13 @@ def _run_ollama_job(
                     **_result_metadata(selection),
                 )
                 continue
-            clean_fields = {}
-            if structured:
-                parsed_fields = {k: v for k, v in structured.items() if k != "filename"}
-                clean_fields = clean_result_fields(
-                    requested_fields=cfg.fields,
-                    parsed_fields=parsed_fields,
-                )
-            field_evidence = {}
-            if cfg.fields:
-                field_evidence = build_field_evidence(
-                    requested_fields=cfg.fields,
-                    parsed_fields=clean_fields,
-                    raw_content=content,
-                    engine=selection.backend,
-                    page=page_num,
-                )
+            clean_fields, field_evidence = _fields_and_evidence(
+                requested_fields=cfg.fields,
+                structured=structured,
+                raw_content=content,
+                engine=selection.backend,
+                page=page_num,
+            )
             yield Result(
                 source=page_filename,
                 mode=mode,
@@ -638,21 +636,12 @@ def _run_ollama_job(
             settings=cfg.settings,
             preprocess=selection.preprocess,
         )
-        clean_fields = {}
-        if structured:
-            parsed_fields = {k: v for k, v in structured.items() if k != "filename"}
-            clean_fields = clean_result_fields(
-                requested_fields=cfg.fields,
-                parsed_fields=parsed_fields,
-            )
-        field_evidence = {}
-        if cfg.fields:
-            field_evidence = build_field_evidence(
-                requested_fields=cfg.fields,
-                parsed_fields=clean_fields,
-                raw_content=content,
-                engine=selection.backend,
-            )
+        clean_fields, field_evidence = _fields_and_evidence(
+            requested_fields=cfg.fields,
+            structured=structured,
+            raw_content=content,
+            engine=selection.backend,
+        )
         elapsed_sec = _number_as_float(result.get("duration_sec")) or 0.0
         dims_t = _dimensions_from_result(result)
         encoded_bytes = _int_value(result.get("encoded_bytes"))
@@ -776,6 +765,59 @@ def _run_hybrid_job_results(
         )
 
 
+def _run_auto_job(
+    *,
+    job: BatchJob,
+    cfg: BatchConfig,
+    mode: Mode,
+    selection: BackendSelection,
+) -> Iterator[Result]:
+    fallback_note: Optional[str] = None
+    if job.kind == "pdf":
+        try:
+            if cfg.fields:
+                docling_results = list(
+                    _run_hybrid_job_results(
+                        job=job,
+                        cfg=cfg,
+                        mode=mode,
+                        selection=selection,
+                    )
+                )
+            else:
+                docling_results = list(
+                    _run_docling_job_results(
+                        job=job,
+                        cfg=cfg,
+                        selection=selection,
+                        engine=BACKEND_DOCLING,
+                    )
+                )
+            yield from docling_results
+            return
+        except Exception as docling_error:
+            fallback_note = f"auto fallback from docling: {docling_error}"
+            _log.info(
+                "auto_docling_fallback",
+                extra={"source": job.source, "err": str(docling_error)},
+            )
+
+    ollama_selection = BackendSelection(
+        backend=BACKEND_OLLAMA,
+        profile_id=selection.profile_id,
+        preprocess=selection.preprocess,
+    )
+    for result in _run_ollama_job(
+        job=job,
+        cfg=cfg,
+        mode=mode,
+        selection=ollama_selection,
+    ):
+        if fallback_note is not None:
+            result.backend_note = fallback_note
+        yield result
+
+
 def run_batch(
     jobs: Iterable[Union[BatchJob, str]],
     cfg: BatchConfig,
@@ -826,49 +868,12 @@ def run_batch(
                 continue
 
             if selection.backend == BACKEND_AUTO:
-                fallback_note: Optional[str] = None
-                if job.kind == "pdf":
-                    try:
-                        if cfg.fields:
-                            docling_results = list(
-                                _run_hybrid_job_results(
-                                    job=job,
-                                    cfg=cfg,
-                                    mode=mode,
-                                    selection=selection,
-                                )
-                            )
-                        else:
-                            docling_results = list(
-                                _run_docling_job_results(
-                                    job=job,
-                                    cfg=cfg,
-                                    selection=selection,
-                                    engine=BACKEND_DOCLING,
-                                )
-                            )
-                        yield from docling_results
-                        continue
-                    except Exception as docling_error:
-                        fallback_note = f"auto fallback from docling: {docling_error}"
-                        _log.info(
-                            "auto_docling_fallback",
-                            extra={"source": job.source, "err": str(docling_error)},
-                        )
-                ollama_selection = BackendSelection(
-                    backend=BACKEND_OLLAMA,
-                    profile_id=selection.profile_id,
-                    preprocess=selection.preprocess,
-                )
-                for result in _run_ollama_job(
+                yield from _run_auto_job(
                     job=job,
                     cfg=cfg,
                     mode=mode,
-                    selection=ollama_selection,
-                ):
-                    if fallback_note is not None:
-                        result.backend_note = fallback_note
-                    yield result
+                    selection=selection,
+                )
                 continue
 
             yield from _run_ollama_job(

--- a/tests/test_app_processing.py
+++ b/tests/test_app_processing.py
@@ -80,6 +80,43 @@ def test_brand_bar_style_targets_streamlit_header():
     assert 'content: "Curiosity AI"' not in style
 
 
+def test_display_entry_from_result_preserves_render_metadata():
+    evidence = {"total": FieldEvidence(value="42", evidence_text="Total 42")}
+    entry = app._display_entry_from_result(
+        Result(
+            source="scan.png",
+            mode="extract",
+            text='{"total": "42"}',
+            fields={"total": "42"},
+            latency_ms=1234,
+            dimensions=(640, 480),
+            encoded_bytes=2048,
+            preview_image_bytes=b"preview",
+            engine="hybrid",
+            profile_id="invoice",
+            backend_note="auto fallback",
+            field_evidence=evidence,
+        )
+    )
+
+    assert entry == {
+        "filename": "scan.png",
+        "content": '{"total": "42"}',
+        "duration_sec": 1.234,
+        "dimensions": (640, 480),
+        "encoded_bytes": 2048,
+        "structured_data": {"filename": "scan.png", "total": "42"},
+        "image_bytes": b"preview",
+        "page_note": None,
+        "status": "done",
+        "error": None,
+        "engine": "hybrid",
+        "profile_id": "invoice",
+        "backend_note": "auto fallback",
+        "field_evidence": evidence,
+    }
+
+
 def test_run_processing_skips_ollama_preflight_for_docling_and_routes_config(monkeypatch):
     fake_st = _FakeStreamlit()
     captured = {}

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -173,6 +173,34 @@ def test_query_ollama_forwards_schema_dict_format():
     assert client.chat.call_args.kwargs["format"] is schema
 
 
+def test_query_ollama_stream_uses_shared_messages_and_timeout():
+    client = Mock()
+    client.chat.return_value = [
+        {"message": {"content": "hello"}},
+        {"message": {"content": ""}},
+        {"message": {"content": " world"}},
+    ]
+
+    with patch.object(adapter.ollama, "Client", return_value=client) as client_factory:
+        chunks = list(
+            adapter.query_ollama_stream(
+                "prompt",
+                "img",
+                "gemma4:latest",
+                system_prompt="system",
+                timeout=2.0,
+            )
+        )
+
+    assert chunks == ["hello", " world"]
+    client_factory.assert_called_once_with(timeout=2.0)
+    assert client.chat.call_args.kwargs["messages"] == [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "prompt", "images": ["img"]},
+    ]
+    assert client.chat.call_args.kwargs["stream"] is True
+
+
 def test_substring_no_longer_matches():
     """Regression: 'gemma4' should NOT match 'gemma4:26b' without explicit tag."""
     with patch.object(adapter.ollama, "show", side_effect=Exception("no")):


### PR DESCRIPTION
Introduce small internal helpers and consolidate logic across core components: simplify PDF page handling in core.pipeline via a _process_page helper and normalize the PDF page tuple semantics; extract field/ evidence construction into _fields_and_evidence and encapsulate AUTO backend fallback into _run_auto_job to centralize docling->ollama fallback routing. In adapters/ollama_adapter.py, centralize message, kwargs and content handling into _messages, _chat_kwargs and _chat_content to unify image/text/stream request construction and timeout usage. In app.py and cli.py, close image file handles using context managers, add pure helpers (_display_entry_from_result and _json_summary_payload) for deterministic display/JSON shaping and replace duplicated payload logic. Update tests to cover display-entry shaping and streaming/message behavior. Update changelog (Updates.MD) with summary of refactors and verification notes.